### PR TITLE
全体タイムラインとフォローした人のタイムラインを分離

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -1,13 +1,13 @@
 class TimelinesController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_user!, only: [:following, :create]
+  before_action :set_new_timeline, only: [:index, :following]
 
   def index
-    if params[:query] == 'following'
-      @timelines = Timeline.following(current_user).eager_load(:user).sorted
-    else
-      @timelines = Timeline.eager_load(:user).sorted
-    end
-    @timeline = Timeline.new
+    @timelines = Timeline.eager_load(:user).sorted
+  end
+
+  def following
+    @timelines = Timeline.following(current_user).eager_load(:user).sorted
   end
 
   def create
@@ -19,5 +19,9 @@ class TimelinesController < ApplicationController
 
   def timeline_params
     params.require(:timeline).permit(:content)
+  end
+
+  def set_new_timeline
+    @timeline = Timeline.new
   end
 end

--- a/app/views/timelines/_list.html.haml
+++ b/app/views/timelines/_list.html.haml
@@ -1,0 +1,7 @@
+%div
+  - @timelines.each do |timeline|
+    %p
+      = link_to timeline.user.username, user_path(timeline.user_id)
+      = timeline.created_at.to_s(:datetime_jp)
+    %p
+      = timeline.content

--- a/app/views/timelines/_new.html.haml
+++ b/app/views/timelines/_new.html.haml
@@ -1,0 +1,5 @@
+- if user_signed_in?
+  %div
+    = simple_form_for @timeline do |f|
+      = f.input_field :content, label: '投稿内容(最大140字)', class: 'form-control'
+      = f.submit '送信', class: 'btn btn-primary'

--- a/app/views/timelines/following.html.haml
+++ b/app/views/timelines/following.html.haml
@@ -1,0 +1,6 @@
+%h2
+  フォローした人のタイムライン
+%div
+  = link_to '全体タイムライン', timelines_path
+= render 'new'
+= render 'list'

--- a/app/views/timelines/index.html.haml
+++ b/app/views/timelines/index.html.haml
@@ -1,21 +1,7 @@
-%h1
-  タイムライン
+%h2
+  全体タイムライン
 - if user_signed_in?
   %div
-    - if params[:query] == 'following'
-      = link_to '全体', timelines_path
-      フォローした人のみ
-    - else
-      全体
-      = link_to 'フォローした人のみ', timelines_path(query: 'following')
-  %div
-    = simple_form_for @timeline do |f|
-      = f.input_field :content, label: '投稿内容(最大140字)', class: 'form-control'
-      = f.submit '送信', class: 'btn btn-primary'
-%div
-  - @timelines.each do |timeline|
-    %p
-      = link_to timeline.user.username, user_path(timeline.user_id)
-      = timeline.created_at.to_s(:datetime_jp)
-    %p
-      = timeline.content
+    = link_to 'フォローした人のみ', following_timelines_path
+= render 'new'
+= render 'list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   root 'timelines#index'
-  resources :timelines, only: [:index, :create]
+  resources :timelines, only: [:index, :create] do
+    collection do
+      get 'following'
+    end
+  end
   resources :users, only: [:show] do
     resource :follows, only: [:create, :destroy]
   end


### PR DESCRIPTION
- timelines#indexのルーティングを2つに分ける
- timelineのviewの共通部分をパーシャル化
   - 投稿フォーム
   - 投稿リスト
- タイトルとリンクの表記を修正